### PR TITLE
fix: Allow 'v2-production-stack' as a new production stack namepsace

### DIFF
--- a/roles/fragalysis-stack/tasks/prep.yaml
+++ b/roles/fragalysis-stack/tasks/prep.yaml
@@ -131,7 +131,7 @@
 
   - name: Check namespace value (non-developer)
     assert:
-      that: stack_namespace in ['staging-stack', 'staging-stack-legacy', 'production-stack', 'production-stack-legacy']
+      that: stack_namespace in ['staging-stack', 'production-stack', 'v2-production-stack']
 
   when: not stack_is_for_developer|bool
 


### PR DESCRIPTION
- Support for `v2-production-stack` as a Namespace